### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/davidtavsilva-source/juice-shop-ada-1466/security/code-scanning/54](https://github.com/davidtavsilva-source/juice-shop-ada-1466/security/code-scanning/54)

To fix the code injection vulnerability, the use of the MongoDB `$where` operator with a JavaScript expression containing user input must be removed. Instead, use a standard query operator (e.g., `{ orderId: id }`) that treats user input as data, not executable code. This maintains the intended functionality of finding orders whose `orderId` matches `id`, but without the risk of arbitrary code execution. Specifically, in `routes/trackOrder.ts`, line 18 can be safely replaced as follows:

**What to do:**  
- Replace the `$where`-based query (`{ $where: ... }`) with a standard query: `{ orderId: id }`
- No changes to imports are needed
- No additional methods or dependencies are required

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
